### PR TITLE
Fix HyperAI import wrappers and control metadata defaults

### DIFF
--- a/digital_ai_organism_framework.py
+++ b/digital_ai_organism_framework.py
@@ -85,15 +85,15 @@ class ControlMetaData:
     """Meta-data control trung tâm cho toàn bộ hệ thống"""
 
     # Basic attributes
-    creator: str = "Andy (alpha_prime_omega)"  # Creator & Copyright Holder
+    creator: str = "Alpha_Prime_Omega"  # Creator & Copyright Holder
     verification_code: int = 4287
     framework_name: str = "HYPERAI Framework"
     license_type: str = "MIT License"
 
     # Extended attributes for creator hierarchy
-    creator: str = "Andy (alpha_prime_omega)"
-    creator_hierarchy: str = "Andy (alpha_prime_omega) - Single Source Creator"
-    symphony_conductor: str = "Andy (alpha_prime_omega)"
+    creator: str = "Alpha_Prime_Omega"
+    creator_hierarchy: str = "Alpha_Prime_Omega -> Andy - Single Source Creator"
+    symphony_conductor: str = "Alpha_Prime_Omega"
 
     @property
     def ultimate_creator(self) -> str:
@@ -201,11 +201,11 @@ class SymphonyControlCenter:
         # Ensure Creator recognition
         if hasattr(component, "creator_source"):
             assert (
-                component.creator == "Andy (alpha_prime_omega)"
+                component.creator == "Alpha_Prime_Omega"
             ), "Ultimate Creator mismatch detected!"
         if hasattr(component, "human_creator"):
             assert (
-                component.creator == "Andy (alpha_prime_omega)"
+                component.creator == "Alpha_Prime_Omega"
             ), "Human Creator mismatch detected!"
 
         self.logger.info(f"🎵 Registered component: {component_name}")

--- a/src/hyperai/components/organism.py
+++ b/src/hyperai/components/organism.py
@@ -9,7 +9,7 @@ Verification: 4287
 """
 
 # Import from package implementation
-from hyperai.digital_ai_organism_framework import DigitalOrganism
+from ..digital_ai_organism_framework import DigitalOrganism
 import importlib
 import warnings
 

--- a/src/hyperai/core/haios_runtime.py
+++ b/src/hyperai/core/haios_runtime.py
@@ -9,8 +9,6 @@ Verification: 4287
 """
 
 # Import from package implementation
-try:
-    from hyperai.haios_runtime import HAIOSRuntime as HAIOSRuntimeImpl
 import importlib
 import warnings
 

--- a/src/hyperai/protocols/dr_protocol.py
+++ b/src/hyperai/protocols/dr_protocol.py
@@ -9,8 +9,6 @@ Verification: 4287
 """
 
 # Import from package implementation if exists
-try:
-    from hyperai.digital_ai_organism_framework import DRProtocol as DRProtocolImpl
 import importlib
 import warnings
 


### PR DESCRIPTION
### Motivation
- Resolve import failures where `src.hyperai` consumer modules raised `ModuleNotFoundError` for `DigitalOrganism` due to an absolute import path.
- Fix a runtime `SyntaxError` caused by malformed `try:` blocks in wrapper modules which prevented fallback behavior during imports.
- Align framework creator metadata with expectations in smoke tests by normalizing the creator identifier and including both source and human names in the hierarchy.

### Description
- Changed the `DigitalOrganism` wrapper import in `src/hyperai/components/organism.py` to a package-relative import (`from ..digital_ai_organism_framework import DigitalOrganism`) so importing via `src.hyperai` works reliably.
- Removed malformed `try:`-without-`except` import lines and restored `importlib`-based fallback loaders in `src/hyperai/core/haios_runtime.py` and `src/hyperai/protocols/dr_protocol.py` so stub fallbacks are used when implementations are absent.
- Updated `ControlMetaData` defaults in `digital_ai_organism_framework.py` to use `Alpha_Prime_Omega` as the primary creator, set `symphony_conductor` to `Alpha_Prime_Omega`, and modified `creator_hierarchy` to include both `Alpha_Prime_Omega` and `Andy` so tests expecting both identifiers pass.
- Adjusted creator-matching checks in the framework to match the new identifier where components are validated during registration.

### Testing
- Ran an initial full test run with `pytest -q tests/test_smoke.py tests/test_module_imports.py tests/test_enhanced_issue_handler.py` which surfaced the failures and guided fixes (12 failures observed before changes).
- After applying fixes, ran focused validation with `pytest -q tests/test_smoke.py::TestSymphonyControlCenter::test_symphony_initialization tests/test_smoke.py::TestControlMetaData::test_metadata_creator_hierarchy tests/test_module_imports.py::TestModuleImports::test_core_imports` and all selected tests passed.
- No other automated tests were modified; the modified files were committed after verification of the focused test set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e7973d45c8329a9dff5f9756a4b47)